### PR TITLE
Account fix

### DIFF
--- a/src/net/wespot/oauth2/provider/AccountService.java
+++ b/src/net/wespot/oauth2/provider/AccountService.java
@@ -113,7 +113,7 @@ public class AccountService {
             accountOfi.setName(accountJson.getString("firstname") + " " + accountJson.getString("familyName"));
             accountOfi.setFamilyName(accountJson.getString("familyName"));
             accountOfi.setGivenName(accountJson.getString("firstname"));
-            if (accountJson.has("pictureUrl")) account.setPictureUrl(accountJson.getString("pictureUrl"));
+            if (accountJson.has("pictureUrl")) accountOfi.setPictureUrl(accountJson.getString("pictureUrl"));
             accountOfi.setEmail(accountJson.getString("email"));
 
 

--- a/src/net/wespot/oauth2/provider/AccountService.java
+++ b/src/net/wespot/oauth2/provider/AccountService.java
@@ -101,13 +101,19 @@ public class AccountService {
 
         try {
             JSONObject accountJson = new JSONObject(account);
-            Account accountOfi = new Account(accountJson.getString("username"),accountJson.getString("username")) ;
+            String username = accountJson.getString("username");
+
+            if (ObjectifyService.ofy().load().key(Key.create(Account.class, username)).now() != null) {
+                return "Account already exists!";
+            }
+
+            Account accountOfi = new Account(username, username) ;
             accountOfi.setPasswordHash(hash(accountJson.getString("password")));
 
-            accountOfi.setName(accountJson.getString("firstname")+" "+accountJson.getString("familyName"));
+            accountOfi.setName(accountJson.getString("firstname") + " " + accountJson.getString("familyName"));
             accountOfi.setFamilyName(accountJson.getString("familyName"));
             accountOfi.setGivenName(accountJson.getString("firstname"));
-            if (accountJson.has("pictureUrl")) accountOfi.setPictureUrl(accountJson.getString("pictureUrl"));
+            if (accountJson.has("pictureUrl")) account.setPictureUrl(accountJson.getString("pictureUrl"));
             accountOfi.setEmail(accountJson.getString("email"));
 
 


### PR DESCRIPTION
### Problem
The createAccount method on `oauth/account/createAccount` wouldn't actually check wether an account existed before creating the new one.

### Implications
Because of this, everyone can change another's account data by simply making a request to `oauth/account/createAccount` with that person's username and different userdata.

### Solution
I added an account exists check so that it first verifies that the account doesn't exist yet. If the account does exist, it doesn't create the new user. 

*Please note:* this code isn't actually tested.